### PR TITLE
semicon_escape_fix

### DIFF
--- a/FilterHTML.py
+++ b/FilterHTML.py
@@ -74,7 +74,6 @@ HTML_ESCAPE_CHARS = {
    '>': '&gt;',
    '<': '&lt;',
    '&': '&amp;',
-   ';': '&semi;',
 }
 
 HTML_ESCAPE_QUOTES = {


### PR DESCRIPTION
This is related to a previous bug in [rich text widget](https://openlearning.atlassian.net/browse/BUFF-5802) and a recent bug report in [blog](https://help.openlearning.com/t/83hkw7h/html-escape-causes-semi-to-appear-in-text).

Do we need to escape semicon here?
In PageController.filterHTML, we have a two step process to convert text to html
- BeautifulSoup
- FilterHTML.filter_html

If there is a `;` in the text, 
- 1st step BeautifulSoup converts `;` to `&semi;` , 
- then 2nd the FilterHtml converts the last `;` into `&semi;` 

So a single `;` in text turns into `&semi&semi;` after the 2 steps.

I think the `BeautifulSoup` already takes care of the `;` escaping, so maybe we don't need to escape it again here?